### PR TITLE
rename generic function graph to to_networkx

### DIFF
--- a/src/graphpro/graph.py
+++ b/src/graphpro/graph.py
@@ -51,12 +51,16 @@ class Graph():
         return [(community.modularity(self.graph(), com), com)
                 for com in c_iter]
 
-    def graph(self) -> nx.Graph:
+    def to_networkx(self) -> nx.Graph:
         """ Returns a networkx G undirected graph with populated attributes """
         G = nx.from_numpy_array(self.distances)
         nx.set_node_attributes(G, self._n_attr)
         return G
 
+    def nodes(self) -> list[int]:
+        """ Return node collection """
+        return self._resid_to_node.values()
+        
     def plot(self,
              figsize: tuple[int, int] = (8, 10),
              communities: list[set[int]] = []

--- a/test/graphpro/annotations_test.py
+++ b/test/graphpro/annotations_test.py
@@ -12,5 +12,5 @@ u1 = mda.Universe(PDB)
 def test_resname_annotation():
     G = md_analisys(u1).generate(ContactMap(cutoff=6), [ResidueType()])
 
-    assert len(G.graph().nodes) == 214
+    assert len(G.nodes()) == 214
     assert G.node_attr(0)['resname'] == 'M'

--- a/test/graphpro/graph_test.py
+++ b/test/graphpro/graph_test.py
@@ -22,7 +22,7 @@ HETNAM_G = md_analisys(HETNAM).generate(ContactMap(cutoff=6), [ResidueType()])
 
 
 def test_graph():
-    assert (len(SIMPLE_G.graph().nodes) == 2)
+    assert (len(SIMPLE_G.nodes()) == 2)
 
 
 def test_graph_allow_add_node_attributes():

--- a/test/graphpro/graphgen_test.py
+++ b/test/graphpro/graphgen_test.py
@@ -13,7 +13,7 @@ u1 = mda.Universe(PDB, XTC)
 
 def test_graph_generation_from_mdanalysis():
     G = md_analisys(u1).generate(ContactMap(cutoff=6))
-    assert(len(G.graph().nodes) == 214)
+    assert(len(G.nodes()) == 214)
 
 
 def test_graph_generation_from_mdanalysis_custom_residue():
@@ -22,7 +22,7 @@ def test_graph_generation_from_mdanalysis_custom_residue():
             os.path.realpath(__file__)) +
         '/../testdata/hetnam.pdb')
     G = md_analisys(hetnam).generate(ContactMap(cutoff=6))
-    assert(len(G.graph().nodes) == 5752)
+    assert(len(G.nodes()) == 5752)
 
 
 def test_graph_generation_collection():


### PR DESCRIPTION
graph() is not descriptive and is overuse to take advantage of networkx functions, this renames the `.graph()` method in a graphpro graph, to `to_networkx` that describes the clear propouse of a transformation to a different library.