### PR TITLE
change graph to undirected, improve cco calculation

### DIFF
--- a/test/graphpro/graph_test.py
+++ b/test/graphpro/graph_test.py
@@ -47,9 +47,9 @@ def test_graph_plot():
     SIMPLE_G.plot(show=False)
 
 def test_to_data_index():
-    edge_index = torch.tensor([[0, 0, 1, 0, 1, 1],
-                  [0, 1, 1, 0, 0, 1]], dtype=torch.long)    
+    edge_index = torch.tensor([[0, 0, 1, 1],[0, 1, 0, 1]])    
     assert(torch.allclose(SIMPLE_G.to_data().edge_index,  edge_index))
+    assert(SIMPLE_G.to_data().is_directed() == False)
 
 def test_to_data_x_transformer():    
     assert SIMPLE_G_ATTR.to_data(node_encoders=[ResidueType()]).x.size() == (2,22)


### PR DESCRIPTION
First implementation of graphpro did not compromised the directonability of the graph, now as most of most methods do not consider the construction of the graph to be indirected, we target a faster and simple construction of edge index.